### PR TITLE
Second attempt - added light mode & some UI tweaks for usability.

### DIFF
--- a/frontend/packages/app/src/components/ContentArea.tsx
+++ b/frontend/packages/app/src/components/ContentArea.tsx
@@ -22,6 +22,7 @@ const ContentWrapper = styled.div`
   gap: 24px;
   height: 100%;
   min-height: 0;
+  overflow-y: auto;
 `;
 
 const EmptyState = styled.div`

--- a/frontend/packages/app/src/components/SettingsModal.tsx
+++ b/frontend/packages/app/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import {
   Checkbox,
   TextArea,
   Flex,
+  Switch,
   Tooltip,
 } from '@radix-ui/themes';
 import * as Tabs from '@radix-ui/react-tabs';
@@ -17,6 +18,7 @@ import type { UserSettings, UserSettingsUpdate } from '@dna/core';
 import type { HotkeyAction } from '../hotkeys/hotkeysConfig';
 import { apiHandler } from '../api';
 import { useHotkeyConfig } from '../hotkeys';
+import { useThemeMode } from '../contexts';
 
 interface SettingsModalProps {
   userEmail: string;
@@ -143,6 +145,18 @@ const StyledTabsTrigger = styled(Tabs.Trigger)`
   }
 `;
 
+const AppearanceRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.subtle};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
 const KeybindingRow = styled.div`
   display: flex;
   align-items: center;
@@ -225,6 +239,8 @@ function GeneralTab({
   onRegenerateOnVersionChange,
   onRegenerateOnTranscriptUpdate,
 }: GeneralTabProps) {
+  const { mode, setMode } = useThemeMode();
+
   if (isLoading) {
     return (
       <Flex align="center" justify="center" py="6">
@@ -235,6 +251,20 @@ function GeneralTab({
 
   return (
     <ModalContent>
+      <Section>
+        <SectionTitle>Appearance</SectionTitle>
+        <AppearanceRow>
+          <KeybindingLabel>
+            <KeybindingName>Light Mode</KeybindingName>
+            <KeybindingDesc>Switch between dark and light theme</KeybindingDesc>
+          </KeybindingLabel>
+          <Switch
+            checked={mode === 'light'}
+            onCheckedChange={(checked) => setMode(checked ? 'light' : 'dark')}
+          />
+        </AppearanceRow>
+      </Section>
+
       <Section>
         <SectionTitle>
           Note Taking Prompt

--- a/frontend/packages/app/src/components/Sidebar.tsx
+++ b/frontend/packages/app/src/components/Sidebar.tsx
@@ -374,7 +374,6 @@ export function Sidebar({
               <Button
                 size="2"
                 variant="solid"
-                color="violet"
                 onClick={() => setIsPublishDialogOpen(true)}
               >
                 Publish Notes

--- a/frontend/packages/app/src/components/TranscriptionMenu.tsx
+++ b/frontend/packages/app/src/components/TranscriptionMenu.tsx
@@ -493,7 +493,6 @@ export function TranscriptionMenu({
               </Button>
             ) : (
               <Button
-                color="violet"
                 variant="solid"
                 onClick={handleDispatch}
                 disabled={isDispatching || !meetingUrl.trim() || !playlistId}

--- a/frontend/packages/app/src/components/VersionHeader.tsx
+++ b/frontend/packages/app/src/components/VersionHeader.tsx
@@ -105,7 +105,7 @@ const NextVersionButton = styled.button`
   font-size: 14px;
   font-weight: 500;
   font-family: ${({ theme }) => theme.fonts.sans};
-  color: ${({ theme }) => theme.colors.text.primary};
+  color: #ffffff;
   background: ${({ theme }) => theme.colors.accent.main};
   border: none;
   border-radius: ${({ theme }) => theme.radii.md};

--- a/frontend/packages/app/src/contexts/ThemeContext.tsx
+++ b/frontend/packages/app/src/contexts/ThemeContext.tsx
@@ -1,0 +1,45 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  type ReactNode,
+} from 'react';
+
+export type ThemeMode = 'dark' | 'light';
+
+const STORAGE_KEY = 'dna-theme-mode';
+
+interface ThemeModeContextValue {
+  mode: ThemeMode;
+  setMode: (mode: ThemeMode) => void;
+}
+
+const ThemeModeContext = createContext<ThemeModeContextValue | null>(null);
+
+export function ThemeModeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<ThemeMode>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'light' ? 'light' : 'dark';
+  });
+
+  const setMode = useCallback((next: ThemeMode) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setModeState(next);
+  }, []);
+
+  return (
+    <ThemeModeContext.Provider value={{ mode, setMode }}>
+      {children}
+    </ThemeModeContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useThemeMode(): ThemeModeContextValue {
+  const ctx = useContext(ThemeModeContext);
+  if (!ctx) {
+    throw new Error('useThemeMode must be used within ThemeModeProvider');
+  }
+  return ctx;
+}

--- a/frontend/packages/app/src/contexts/index.ts
+++ b/frontend/packages/app/src/contexts/index.ts
@@ -1,3 +1,5 @@
 export { EventProvider, useEventContext, useEventClient } from './EventContext';
 export type { EventType, DNAEvent, EventCallback } from './EventContext';
 export { ToastProvider, useToast } from './ToastContext';
+export { ThemeModeProvider, useThemeMode } from './ThemeContext';
+export type { ThemeMode } from './ThemeContext';

--- a/frontend/packages/app/src/hotkeys/useHotkeyAction.ts
+++ b/frontend/packages/app/src/hotkeys/useHotkeyAction.ts
@@ -18,8 +18,8 @@ export function useHotkeyAction(
   const hotkeyOptions: Options = {
     preventDefault: true,
     enabled: options?.enabled ?? true,
-    enableOnFormTags: options?.enableOnFormTags,
-    enableOnContentEditable: options?.enableOnContentEditable,
+    enableOnFormTags: options?.enableOnFormTags ?? true,
+    enableOnContentEditable: options?.enableOnContentEditable ?? true,
   };
 
   useHotkeys(keys, callback, hotkeyOptions, [keys, callback]);

--- a/frontend/packages/app/src/main.tsx
+++ b/frontend/packages/app/src/main.tsx
@@ -4,29 +4,39 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'styled-components';
 import { Theme } from '@radix-ui/themes';
 import App from './App';
-import { theme, GlobalStyles } from './styles';
-import { EventProvider, ToastProvider } from './contexts';
+import { darkTheme, lightTheme, GlobalStyles } from './styles';
+import { EventProvider, ToastProvider, ThemeModeProvider, useThemeMode } from './contexts';
 import { HotkeysProvider } from './hotkeys';
 import '@radix-ui/themes/styles.css';
 import './index.css';
 
 const queryClient = new QueryClient();
 
+function ThemedApp() {
+  const { mode } = useThemeMode();
+  const activeTheme = mode === 'light' ? lightTheme : darkTheme;
+  return (
+    <ThemeProvider theme={activeTheme}>
+      <Theme appearance={mode} accentColor="violet">
+        <GlobalStyles />
+        <HotkeysProvider>
+          <ToastProvider>
+            <EventProvider>
+              <App />
+            </EventProvider>
+          </ToastProvider>
+        </HotkeysProvider>
+      </Theme>
+    </ThemeProvider>
+  );
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <Theme appearance="dark" accentColor="violet">
-          <GlobalStyles />
-          <HotkeysProvider>
-            <ToastProvider>
-              <EventProvider>
-                <App />
-              </EventProvider>
-            </ToastProvider>
-          </HotkeysProvider>
-        </Theme>
-      </ThemeProvider>
+      <ThemeModeProvider>
+        <ThemedApp />
+      </ThemeModeProvider>
     </QueryClientProvider>
   </StrictMode>
 );

--- a/frontend/packages/app/src/styles/GlobalStyles.ts
+++ b/frontend/packages/app/src/styles/GlobalStyles.ts
@@ -9,7 +9,7 @@ export const GlobalStyles = createGlobalStyle`
     font-family: ${({ theme }) => theme.fonts.sans};
     line-height: 1.5;
     font-weight: 400;
-    color-scheme: dark;
+    color-scheme: ${({ theme }) => theme.colors.bg.base === '#ffffff' ? 'light' : 'dark'};
     color: ${({ theme }) => theme.colors.text.primary};
     background-color: ${({ theme }) => theme.colors.bg.base};
     font-synthesis: none;

--- a/frontend/packages/app/src/styles/index.ts
+++ b/frontend/packages/app/src/styles/index.ts
@@ -1,3 +1,3 @@
-export { theme } from './theme';
+export { theme, darkTheme, lightTheme } from './theme';
 export type { Theme } from './theme';
 export { GlobalStyles } from './GlobalStyles';

--- a/frontend/packages/app/src/styles/theme.ts
+++ b/frontend/packages/app/src/styles/theme.ts
@@ -1,41 +1,4 @@
-export const theme = {
-  colors: {
-    bg: {
-      base: '#0d0d12',
-      elevated: '#14141b',
-      surface: '#1a1a24',
-      surfaceHover: '#22222f',
-      overlay: '#252532',
-    },
-    sidebar: {
-      bg: '#111118',
-      border: '#2a2a3a',
-    },
-    text: {
-      primary: '#f0f0f5',
-      secondary: '#a0a0b8',
-      muted: '#6b6b82',
-      inverse: '#0d0d12',
-    },
-    accent: {
-      main: '#8b5cf6',
-      hover: '#7c3aed',
-      subtle: 'rgba(139, 92, 246, 0.12)',
-      glow: 'rgba(139, 92, 246, 0.25)',
-      gradient: 'linear-gradient(135deg, #8b5cf6 0%, #c084fc 100%)',
-    },
-    status: {
-      success: '#22c55e',
-      warning: '#f59e0b',
-      error: '#ef4444',
-      info: '#3b82f6',
-    },
-    border: {
-      subtle: 'rgba(255, 255, 255, 0.06)',
-      default: 'rgba(255, 255, 255, 0.1)',
-      strong: 'rgba(255, 255, 255, 0.15)',
-    },
-  },
+const base = {
   sizes: {
     sidebar: {
       expanded: '420px',
@@ -62,6 +25,83 @@ export const theme = {
     sans: "'DM Sans', system-ui, -apple-system, sans-serif",
     mono: "'JetBrains Mono', 'Fira Code', monospace",
   },
+};
+
+const sharedColors = {
+  accent: {
+    main: '#8b5cf6',
+    hover: '#7c3aed',
+    subtle: 'rgba(139, 92, 246, 0.12)',
+    glow: 'rgba(139, 92, 246, 0.25)',
+    gradient: 'linear-gradient(135deg, #8b5cf6 0%, #c084fc 100%)',
+  },
+  status: {
+    success: '#22c55e',
+    warning: '#f59e0b',
+    error: '#ef4444',
+    info: '#3b82f6',
+  },
+};
+
+export const darkTheme = {
+  ...base,
+  colors: {
+    ...sharedColors,
+    bg: {
+      base: '#0d0d12',
+      elevated: '#14141b',
+      surface: '#1a1a24',
+      surfaceHover: '#22222f',
+      overlay: '#252532',
+    },
+    sidebar: {
+      bg: '#111118',
+      border: '#2a2a3a',
+    },
+    text: {
+      primary: '#f0f0f5',
+      secondary: '#a0a0b8',
+      muted: '#6b6b82',
+      inverse: '#0d0d12',
+    },
+    border: {
+      subtle: 'rgba(255, 255, 255, 0.06)',
+      default: 'rgba(255, 255, 255, 0.1)',
+      strong: 'rgba(255, 255, 255, 0.15)',
+    },
+  },
 } as const;
 
-export type Theme = typeof theme;
+export const lightTheme = {
+  ...base,
+  colors: {
+    ...sharedColors,
+    bg: {
+      base: '#ffffff',
+      elevated: '#f5f5f7',
+      surface: '#f0f0f3',
+      surfaceHover: '#e8e8ed',
+      overlay: '#e4e4ea',
+    },
+    sidebar: {
+      bg: '#f8f8fb',
+      border: '#e0e0e8',
+    },
+    text: {
+      primary: '#0d0d12',
+      secondary: '#4a4a62',
+      muted: '#8a8aa0',
+      inverse: '#ffffff',
+    },
+    border: {
+      subtle: 'rgba(0, 0, 0, 0.06)',
+      default: 'rgba(0, 0, 0, 0.1)',
+      strong: 'rgba(0, 0, 0, 0.15)',
+    },
+  },
+} as const;
+
+// backwards-compatible default export
+export const theme = darkTheme;
+
+export type Theme = typeof darkTheme;


### PR DESCRIPTION
_In accordance with TAC discussions in the ASWF's slack channel, I am noting here that Claude Opus 4.6 was used to make the following changes:_

1. **Light Mode** (`theme.ts`, `GlobalStyles.ts`, `ThemeContext.tsx`, `main.tsx`, `SettingsModal.tsx`, `contexts/index.ts`, `styles/index.ts`)
Split the theme into `darkTheme` and `lightTheme`. Added `ThemeModeProvider` context that persists the preference to `localStorage`. Wired a `ThemedApp` component in `main.tsx` to swap themes dynamically. Added an Appearance section to the General settings tab with a light/dark toggle. Also fixed the "Publish Notes" and transcription dispatch buttons to inherit accent color from the theme rather than hardcoding `color="violet"`, and fixed the Next Version button text to always be white (`#ffffff`) - just for now? pending more theming in future...

2. **Transcript Tab Overflow** (`ContentArea.tsx`)
Added `overflow-y: auto` to `ContentWrapper` so that when the browser window is too small to fit all the content, the content area scrolls instead of the transcript panel overlapping the note editor.

3. **Hotkeys While Typing** (`useHotkeyAction.ts`)
Set `enableOnFormTags` and `enableOnContentEditable` to `true` by default in `useHotkeyAction`, so all registered hotkeys (next/previous version, set in review, AI insert/regenerate, toggle sidebar, open settings) fire even when the note editor or a form input has focus.

![light_mode](https://github.com/user-attachments/assets/fcc93789-d615-4eaf-85f4-4778f60099d8)
