### PR TITLE
Allows anyone to login when using mock PT provider

### DIFF
--- a/backend/src/dna/prodtrack_providers/mock_provider.py
+++ b/backend/src/dna/prodtrack_providers/mock_provider.py
@@ -513,16 +513,17 @@ class MockProdtrackProvider(ProdtrackProviderBase):
             (user_email,),
         ).fetchone()
         if not row:
-            raise ValueError(f"User not found: {user_email}")
+            return User(
+                id=-1,
+                name=user_email,
+                email=user_email,
+                login=user_email,
+            )
         return self._user_from_row(row)
 
     def get_projects_for_user(self, user_email: str) -> list[Project]:
-        user_row = self.get_user_by_email(user_email)
         conn = self._get_conn()
-        rows = conn.execute(
-            "SELECT p.id, p.name FROM projects p JOIN project_users pu ON p.id = pu.project_id WHERE pu.user_id = ?",
-            (user_row.id,),
-        ).fetchall()
+        rows = conn.execute("SELECT id, name FROM projects").fetchall()
         return [self._project_from_row(r) for r in rows]
 
     def get_playlists_for_project(self, project_id: int) -> list[Playlist]:

--- a/backend/tests/providers/test_mock_provider.py
+++ b/backend/tests/providers/test_mock_provider.py
@@ -268,9 +268,12 @@ def test_search_shot_with_project_id(mock_provider):
     assert results[0]["id"] == 100
 
 
-def test_get_user_by_email_not_found_raises(mock_provider):
-    with pytest.raises(ValueError, match="User not found: nobody@example.com"):
-        mock_provider.get_user_by_email("nobody@example.com")
+def test_get_user_by_email_not_found_returns_synthetic_user(mock_provider):
+    user = mock_provider.get_user_by_email("nobody@example.com")
+    assert user.id == -1
+    assert user.email == "nobody@example.com"
+    assert user.name == "nobody@example.com"
+    assert user.login == "nobody@example.com"
 
 
 def test_get_user_by_email_returns_user(mock_provider):
@@ -416,14 +419,16 @@ def test_get_user_by_email(mock_provider):
 
 
 def test_get_user_by_email_not_found(mock_provider):
-    with pytest.raises(ValueError, match="User not found: nobody@example.com"):
-        mock_provider.get_user_by_email("nobody@example.com")
+    user = mock_provider.get_user_by_email("nobody@example.com")
+    assert user.id == -1
+    assert user.email == "nobody@example.com"
 
 
 def test_get_projects_for_user(mock_provider):
     projects = mock_provider.get_projects_for_user("test@example.com")
-    assert len(projects) == 1
-    assert projects[0].id == 1
+    assert len(projects) >= 1
+    project_ids = [p.id for p in projects]
+    assert 1 in project_ids
 
 
 def test_get_playlists_for_project(mock_provider):

--- a/frontend/packages/app/src/components/ProjectSelector.tsx
+++ b/frontend/packages/app/src/components/ProjectSelector.tsx
@@ -413,7 +413,7 @@ export function ProjectSelector({ onSelectionComplete }: ProjectSelectorProps) {
                 }
               }}
             >
-              <Label>Enter your ShotGrid email</Label>
+              <Label>Enter your email</Label>
               <StyledInput
                 type="email"
                 placeholder="you@example.com"


### PR DESCRIPTION
# Summary

This change allows users who are not in the mockdb to login.

- Updated `get_user_by_email` to return a synthetic user with default values instead of raising an error when the user is not found.
- Adjusted tests to reflect this change, ensuring they validate the synthetic user properties.
- Modified `get_projects_for_user` to fetch all projects without filtering by user ID.

## Testing
- [X] I have tested these changes locally
- [X] I have run all relevant automated tests
- [X] I have verified this does not break existing workflows
- [X] For changes that can be tested in UI, I have included screenshots or gif animations of the changes.

<img width="588" height="653" alt="Screenshot 2026-03-09 at 9 43 57 AM" src="https://github.com/user-attachments/assets/9158c0a2-5e8d-4008-8a62-f4bbc1cf78a8" />

## How I Tested
Was able to use the app even if the user is not in the mock DB

