### PR TITLE
Handle 403 errors when using noop auth provider

### DIFF
--- a/frontend/packages/app/src/contexts/AuthContext.tsx
+++ b/frontend/packages/app/src/contexts/AuthContext.tsx
@@ -64,6 +64,13 @@ function NoopAuthProviderInner({ children }: NoopAuthProviderInnerProps) {
   });
 
   useEffect(() => {
+    if (token === 'noop-token' && user?.email) {
+      localStorage.setItem(STORAGE_KEY, user.email);
+      setToken(user.email);
+    }
+  }, [token, user?.email]);
+
+  useEffect(() => {
     if (token && user) {
       apiHandler.setUser({
         id: user.id,
@@ -91,7 +98,7 @@ function NoopAuthProviderInner({ children }: NoopAuthProviderInnerProps) {
       name: email.split('@')[0],
     };
 
-    const noopToken = 'noop-token';
+    const noopToken = email;
 
     localStorage.setItem(STORAGE_KEY, noopToken);
     localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(authUser));


### PR DESCRIPTION
- Added a useEffect to store user email in localStorage when the token is 'noop-token'.
- Updated noopToken assignment to use the user's email instead of a static value.

# Summary
Resolves issues with 403 returns when editting settings with the noop provider

## Testing
- [X] I have tested these changes locally
- [X] I have run all relevant automated tests
- [X] I have verified this does not break existing workflows
- [X] For changes that can be tested in UI, I have included screenshots or gif animations of the changes.

## How I Tested
Tested locally with noop auth provider

<img width="712" height="865" alt="image" src="https://github.com/user-attachments/assets/0d9f351e-acc5-4553-a7d5-545421e5389d" />
