### PR TITLE
hid Other Notes Tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ experimental/cameron/frontend_v3/venv
 KEYBINDINGS/
 backend/docker-compose.debug.yml
 backend/docker-compose.vexa.yml
-
+backend/docker-compose.override.yml
 
 # Cursor files
 *.issue-body-temp.md*

--- a/frontend/packages/app/src/components/AssistantPanel.tsx
+++ b/frontend/packages/app/src/components/AssistantPanel.tsx
@@ -9,6 +9,8 @@ import { useAISuggestion } from '../hooks';
 import { useHotkeyAction } from '../hotkeys';
 
 const isDevMode = import.meta.env.VITE_DEV_MODE === 'true';
+// To re-enable the Other Pending Notes tab, set this to true
+const SHOW_OTHER_NOTES_TAB = false;
 
 interface AssistantPanelProps {
   activeTab?: string;
@@ -96,8 +98,7 @@ export function AssistantPanel({
         <StyledTabsList>
           <StyledTabsTrigger value="assistant">AI Assistant</StyledTabsTrigger>
           <StyledTabsTrigger value="transcript">Transcript</StyledTabsTrigger>
-          {/* Other Pending Notes tab hidden — to re-enable, remove the `{false && ...}` wrapper below */}
-          {false && (
+          {SHOW_OTHER_NOTES_TAB && (
             <StyledTabsTrigger value="other">
               Other Pending Notes
             </StyledTabsTrigger>
@@ -124,14 +125,16 @@ export function AssistantPanel({
           />
         </StyledTabsContent>
 
-        <StyledTabsContent value="other">
-          <OtherNotesPanel
-            playlistId={playlistId}
-            versionId={versionId}
-            userEmail={userEmail}
-            onInsertNote={onInsertNote}
-          />
-        </StyledTabsContent>
+        {SHOW_OTHER_NOTES_TAB && (
+          <StyledTabsContent value="other">
+            <OtherNotesPanel
+              playlistId={playlistId}
+              versionId={versionId}
+              userEmail={userEmail}
+              onInsertNote={onInsertNote}
+            />
+          </StyledTabsContent>
+        )}
 
         {isDevMode && (
           <StyledTabsContent value="debug">

--- a/frontend/packages/app/src/components/AssistantPanel.tsx
+++ b/frontend/packages/app/src/components/AssistantPanel.tsx
@@ -96,9 +96,12 @@ export function AssistantPanel({
         <StyledTabsList>
           <StyledTabsTrigger value="assistant">AI Assistant</StyledTabsTrigger>
           <StyledTabsTrigger value="transcript">Transcript</StyledTabsTrigger>
-          <StyledTabsTrigger value="other">
-            Other Pending Notes
-          </StyledTabsTrigger>
+          {/* Other Pending Notes tab hidden */}
+          {false && (
+            <StyledTabsTrigger value="other">
+              Other Pending Notes
+            </StyledTabsTrigger>
+          )}
           {isDevMode && (
             <StyledTabsTrigger value="debug">Prompt Debug</StyledTabsTrigger>
           )}

--- a/frontend/packages/app/src/components/AssistantPanel.tsx
+++ b/frontend/packages/app/src/components/AssistantPanel.tsx
@@ -96,7 +96,7 @@ export function AssistantPanel({
         <StyledTabsList>
           <StyledTabsTrigger value="assistant">AI Assistant</StyledTabsTrigger>
           <StyledTabsTrigger value="transcript">Transcript</StyledTabsTrigger>
-          {/* Other Pending Notes tab hidden */}
+          {/* Other Pending Notes tab hidden — to re-enable, remove the `{false && ...}` wrapper below */}
           {false && (
             <StyledTabsTrigger value="other">
               Other Pending Notes


### PR DESCRIPTION
# Summary
Hid the other notes tab. Note: This commit was done with the help of Claude code plugged into Zed code editor. 

## Testing
- [x] I have tested these changes locally
- [x] I have run all relevant automated tests
- [x] I have verified this does not break existing workflows
- [x] For changes that can be tested in UI, I have included screenshots or gif animations of the changes.

## How I Tested
I stood the application up and tried to click the area where the other notes tab existed before. I looked at the console to see if any errors were being produced at refresh of page or by clicking around. 

<img width="756" height="642" alt="Screenshot 2026-05-14 at 7 10 16 PM" src="https://github.com/user-attachments/assets/5b2cdc89-a1a8-4581-978a-5c4332d4b627" />
