### PR TITLE
Feature/playlist scratch notes only

### DIFF
--- a/backend/src/dna/models/__init__.py
+++ b/backend/src/dna/models/__init__.py
@@ -4,6 +4,7 @@ Pydantic models for DNA entities.
 """
 
 from dna.models.draft_note import (
+    SCRATCH_VERSION_ID,
     DraftNote,
     DraftNoteBase,
     DraftNoteCreate,
@@ -117,6 +118,7 @@ __all__ = [
     "PublishTranscriptResponse",
     "UpdateVersionStatusRequest",
     "UpdateVersionStatusResponse",
+    "SCRATCH_VERSION_ID",
     "DraftNote",
     "DraftNoteBase",
     "DraftNoteCreate",

--- a/backend/src/dna/models/draft_note.py
+++ b/backend/src/dna/models/draft_note.py
@@ -8,6 +8,11 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# Sentinel version_id for a playlist-level "scratch" note: the draft belongs to
+# the playlist itself rather than any version, and publishes as a note linked
+# only to the Playlist entity.
+SCRATCH_VERSION_ID = -1
+
 
 class DraftNoteLink(BaseModel):
     """Reference to a DNA entity to link to the note."""

--- a/backend/src/dna/models/playlist_metadata.py
+++ b/backend/src/dna/models/playlist_metadata.py
@@ -23,6 +23,11 @@ class PlaylistMetadataUpdate(BaseModel):
     transcription_paused: Optional[bool] = Field(
         default=None, description="Whether transcription storage is paused"
     )
+    has_scratch: Optional[bool] = Field(
+        default=None,
+        description="Whether the playlist has a scratch tile — a placeholder "
+        "for a note on the playlist entity rather than on a version.",
+    )
     clear_resumed_at: bool = Field(
         default=False,
         description="If True, clears transcription_resumed_at. "
@@ -42,6 +47,7 @@ class PlaylistMetadata(BaseModel):
     platform: Optional[str] = None
     vexa_meeting_id: Optional[int] = None
     transcription_paused: bool = False
+    has_scratch: bool = False
     transcription_resumed_at: Optional[datetime] = Field(
         default=None,
         description="Timestamp when transcription was last resumed. "

--- a/backend/src/dna/prodtrack_providers/prodtrack_provider_base.py
+++ b/backend/src/dna/prodtrack_providers/prodtrack_provider_base.py
@@ -210,6 +210,33 @@ class ProdtrackProviderBase:
         """
         raise NotImplementedError("Subclasses must implement this method.")
 
+    def publish_playlist_note(
+        self,
+        playlist_id: int,
+        content: str,
+        subject: str,
+        to_users: list[int],
+        cc_users: list[int],
+        links: list["EntityBase"],
+        author_email: str | None = None,
+    ) -> int:
+        """Publish a note linked to a playlist rather than a version.
+
+        Args:
+            playlist_id: The ID of the playlist to link to
+            content: Note content
+            subject: Note subject
+            to_users: List of user IDs to address
+            cc_users: List of user IDs to CC
+            links: List of additional entities to link
+            author_email: Optional email of the author. If provided, the note
+                should be created on behalf of this user.
+
+        Returns:
+            The ID of the created note
+        """
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def update_version_status(self, version_id: int, status: str) -> bool:
         """Update the status of a version without publishing a note.
 

--- a/backend/src/dna/prodtrack_providers/shotgrid.py
+++ b/backend/src/dna/prodtrack_providers/shotgrid.py
@@ -1048,6 +1048,101 @@ class ShotgridProvider(ProdtrackProviderBase):
 
         return result["id"]
 
+    def publish_playlist_note(
+        self,
+        playlist_id: int,
+        content: str,
+        subject: str,
+        to_users: list[int],
+        cc_users: list[int],
+        links: list[EntityBase],
+        author_email: Optional[str] = None,
+    ) -> int:
+        """Publish a note linked to a playlist (no version) in ShotGrid.
+
+        Args:
+            playlist_id: The ID of the playlist to link to.
+            content: Note content.
+            subject: Note subject.
+            to_users: List of user IDs to address.
+            cc_users: List of user IDs to CC.
+            links: List of additional entities to link.
+            author_email: Optional email of the author.
+
+        Returns:
+            The ID of the created (or existing) note.
+        """
+        if not self._sg:
+            raise ValueError("Not connected to ShotGrid")
+
+        # 1. Fetch playlist to get Project and ensure playlist exists
+        playlist_data = self._sg.find_one(
+            "Playlist",
+            filters=[["id", "is", playlist_id]],
+            fields=["project"],
+        )
+        if not playlist_data:
+            raise ValueError(f"Playlist {playlist_id} not found")
+
+        project = playlist_data.get("project")
+        if not project:
+            raise ValueError(f"Playlist {playlist_id} has no project assigned")
+
+        # 2. Check for duplicates: same playlist link, subject, and content
+        duplicate_filters = [
+            ["project", "is", project],
+            ["note_links", "is", {"type": "Playlist", "id": playlist_id}],
+            ["subject", "is", subject],
+            ["content", "is", content],
+        ]
+        existing_note = self._sg.find_one(
+            "Note", filters=duplicate_filters, fields=["id"]
+        )
+        if existing_note:
+            return existing_note["id"]
+
+        # 3. Prepare Note Data
+        note_links = [{"type": "Playlist", "id": playlist_id}]
+        if links:
+            extra_links = self._convert_entities_to_sg_links(links)
+            if extra_links:
+                if isinstance(extra_links, dict):
+                    note_links.append(extra_links)
+                elif isinstance(extra_links, list):
+                    note_links.extend(extra_links)
+
+        recipient_links = [{"type": "HumanUser", "id": uid} for uid in to_users]
+        cc_links = [{"type": "HumanUser", "id": uid} for uid in cc_users]
+
+        note_data = {
+            "project": project,
+            "subject": subject,
+            "content": content,
+            "note_links": note_links,
+            "addressings_to": recipient_links,
+            "addressings_cc": cc_links,
+        }
+
+        # 4. Handle Author / Sudo
+        author_login = None
+        if author_email:
+            try:
+                author_user = self.get_user_by_email(author_email)
+                if author_user and author_user.login:
+                    author_login = author_user.login
+            except ValueError as e:
+                raise UserNotFoundError(
+                    f"Author not found in ShotGrid: {author_email}"
+                ) from e
+
+        if author_login:
+            with self.sudo(author_login):
+                result = self._sg.create("Note", note_data)
+        else:
+            result = self._sg.create("Note", note_data)
+
+        return result["id"]
+
     def attach_file_to_note(
         self, note_id: int, file_path: str, display_name: str
     ) -> bool:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -32,6 +32,7 @@ from dna.glossary_config import (
 )
 from dna.llm_providers.llm_provider_base import LLMProviderBase, get_llm_provider
 from dna.models import (
+    SCRATCH_VERSION_ID,
     AddVersionToPlaylistRequest,
     Asset,
     BotSession,
@@ -62,7 +63,6 @@ from dna.models import (
     PublishTranscriptResponse,
     RunQCChecksRequest,
     RunQCChecksResponse,
-    SCRATCH_VERSION_ID,
     SearchRequest,
     SearchResult,
     Shot,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -62,6 +62,7 @@ from dna.models import (
     PublishTranscriptResponse,
     RunQCChecksRequest,
     RunQCChecksResponse,
+    SCRATCH_VERSION_ID,
     SearchRequest,
     SearchResult,
     Shot,
@@ -1043,7 +1044,10 @@ async def publish_notes(
 
     for note in notes_to_publish:
         try:
-            status_to_apply = _status_to_apply(note)
+            # Scratch notes belong to the playlist itself: no version, so no
+            # version status to apply.
+            is_scratch = note.version_id == SCRATCH_VERSION_ID
+            status_to_apply = None if is_scratch else _status_to_apply(note)
 
             # Skip notes with no meaningful content to publish
             has_body = (note.content and note.content.strip()) or (
@@ -1100,43 +1104,63 @@ async def publish_notes(
                 )
                 continue
 
-            # Get links
+            # Get links, skipping entities with sentinel ids (e.g. the scratch
+            # pseudo-version) that don't exist in the tracking system
             links = []
             if note.links:
                 for link in note.links:
+                    if link.entity_id <= 0:
+                        continue
                     model_class = ENTITY_MODELS.get(link.entity_type)
                     if model_class:
                         links.append(model_class(id=link.entity_id))
 
-            # Ensure playlist is included in links
-            playlist_link_exists = any(
-                isinstance(l, Playlist) and l.id == playlist_id for l in links
-            )
-            if not playlist_link_exists:
-                links.append(_create_stub_entity("Playlist", playlist_id))
-
-            # Ensure version's parent entity (Shot/Asset) is included in links
-            version = prodtrack.get_entity(
-                "version", note.version_id, resolve_links=False
-            )
-            if version and version.entity:
-                entity_link_exists = any(
-                    l.id == version.entity.id and l.type == version.entity.type
+            if is_scratch:
+                # The provider links the playlist itself; don't pass it twice
+                extra_links = [
+                    l
                     for l in links
+                    if not (isinstance(l, Playlist) and l.id == playlist_id)
+                ]
+                note_id = prodtrack.publish_playlist_note(
+                    playlist_id=playlist_id,
+                    content=note.content,
+                    subject=note.subject,
+                    to_users=[],
+                    cc_users=[],
+                    links=extra_links,
+                    author_email=note.user_email,
                 )
-                if not entity_link_exists:
-                    links.append(version.entity)
+            else:
+                # Ensure playlist is included in links
+                playlist_link_exists = any(
+                    isinstance(l, Playlist) and l.id == playlist_id for l in links
+                )
+                if not playlist_link_exists:
+                    links.append(_create_stub_entity("Playlist", playlist_id))
 
-            note_id = prodtrack.publish_note(
-                version_id=note.version_id,
-                content=note.content,
-                subject=note.subject,
-                to_users=[],  # TODO: Parse to/cc
-                cc_users=[],
-                links=links,
-                author_email=note.user_email,
-                version_status=status_to_apply,
-            )
+                # Ensure version's parent entity (Shot/Asset) is included in links
+                version = prodtrack.get_entity(
+                    "version", note.version_id, resolve_links=False
+                )
+                if version and version.entity:
+                    entity_link_exists = any(
+                        l.id == version.entity.id and l.type == version.entity.type
+                        for l in links
+                    )
+                    if not entity_link_exists:
+                        links.append(version.entity)
+
+                note_id = prodtrack.publish_note(
+                    version_id=note.version_id,
+                    content=note.content,
+                    subject=note.subject,
+                    to_users=[],  # TODO: Parse to/cc
+                    cc_users=[],
+                    links=links,
+                    author_email=note.user_email,
+                    version_status=status_to_apply,
+                )
 
             if note.attachment_ids:
                 _upload_attachments(note_id, note.attachment_ids)

--- a/backend/tests/test_publish_endpoint.py
+++ b/backend/tests/test_publish_endpoint.py
@@ -94,9 +94,7 @@ class TestPublishNotesEndpoint:
             subject="Scratch",
             version_status="rev",  # must be ignored: there is no version
             links=[
-                DraftNoteLink(
-                    entity_type="version", entity_id=SCRATCH_VERSION_ID
-                ),
+                DraftNoteLink(entity_type="version", entity_id=SCRATCH_VERSION_ID),
                 DraftNoteLink(entity_type="shot", entity_id=42),
             ],
             created_at=datetime.now(timezone.utc),

--- a/backend/tests/test_publish_endpoint.py
+++ b/backend/tests/test_publish_endpoint.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from main import app, get_prodtrack_provider_cached, get_storage_provider_cached
 
-from dna.models.draft_note import DraftNote
+from dna.models.draft_note import SCRATCH_VERSION_ID, DraftNote, DraftNoteLink
 
 
 def _targets(*pairs: tuple[str, int]) -> list[dict[str, str | int]]:
@@ -80,6 +80,60 @@ class TestPublishNotesEndpoint:
         assert call_args[1]["user_email"] == "user@example.com"
         assert call_args[1]["data"].published is True
         assert call_args[1]["data"].published_note_id == 500
+
+    def test_publish_scratch_note_links_playlist(
+        self, client, mock_storage, mock_prodtrack, override_deps
+    ):
+        """A scratch draft publishes as a playlist note, never touching a version."""
+        draft_note = DraftNote(
+            _id="scratch1",
+            user_email="user@example.com",
+            playlist_id=100,
+            version_id=SCRATCH_VERSION_ID,
+            content="Playlist-wide observation",
+            subject="Scratch",
+            version_status="rev",  # must be ignored: there is no version
+            links=[
+                DraftNoteLink(
+                    entity_type="version", entity_id=SCRATCH_VERSION_ID
+                ),
+                DraftNoteLink(entity_type="shot", entity_id=42),
+            ],
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            published=False,
+        )
+        mock_storage.get_draft_notes_for_playlist.return_value = [draft_note]
+        mock_prodtrack.publish_playlist_note.return_value = 600
+
+        response = client.post(
+            "/playlists/100/publish-notes",
+            json={
+                "user_email": "user@example.com",
+                "targets": _targets(("user@example.com", SCRATCH_VERSION_ID)),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["published_count"] == 1
+
+        mock_prodtrack.publish_note.assert_not_called()
+        mock_prodtrack.update_version_status.assert_not_called()
+        mock_prodtrack.get_entity.assert_not_called()
+
+        mock_prodtrack.publish_playlist_note.assert_called_once()
+        args = mock_prodtrack.publish_playlist_note.call_args[1]
+        assert args["playlist_id"] == 100
+        assert args["content"] == "Playlist-wide observation"
+        assert args["author_email"] == "user@example.com"
+        # The scratch pseudo-version link is dropped; real links pass through
+        assert [(l.type, l.id) for l in args["links"]] == [("Shot", 42)]
+
+        call_args = mock_storage.upsert_draft_note.call_args
+        assert call_args[1]["version_id"] == SCRATCH_VERSION_ID
+        assert call_args[1]["data"].published is True
+        assert call_args[1]["data"].published_note_id == 600
 
     def test_publish_notes_skips_published(
         self, client, mock_storage, mock_prodtrack, override_deps

--- a/frontend/packages/app/src/components/ContentArea.tsx
+++ b/frontend/packages/app/src/components/ContentArea.tsx
@@ -1,13 +1,14 @@
 import { useRef, useCallback, useMemo, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
+import { SCRATCH_VERSION_ID } from '@dna/core';
 import type { Version, SearchResult, UserSettings } from '@dna/core';
 import { VersionHeader } from './VersionHeader';
 import { NoteEditor, type NoteEditorHandle } from './NoteEditor';
 import { AssistantPanel } from './AssistantPanel';
 import { usePlaylistMetadata, useSetInReview, useDraftNote } from '../hooks';
 import { useHotkeyAction } from '../hotkeys';
-import { apiHandler } from '../api';
+import { apiHandler, useGetUserByEmail } from '../api';
 import { useFeatureFlags } from '../contexts';
 import {
   openProdtrackVersionViaExtensionOrNewTab,
@@ -55,6 +56,14 @@ const EmptyStateText = styled.p`
   font-size: 14px;
 `;
 
+const ScratchTitle = styled.h1`
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  font-family: ${({ theme }) => theme.fonts.sans};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
 function formatDate(dateString?: string): string {
   if (!dateString) return '';
   const date = new Date(dateString);
@@ -79,15 +88,30 @@ export function ContentArea({
   const { transcriptionEnabled, aiEnabled } = useFeatureFlags();
   const assistantPanelVisible = transcriptionEnabled || aiEnabled;
 
+  // Scratch tiles are placeholders for a note on the playlist entity: no
+  // version metadata, AI assistant, transcript, or in-review interactions.
+  const isScratch = version?.id === SCRATCH_VERSION_ID;
+
   const currentVersionAsSearchResult = useMemo((): SearchResult | undefined => {
-    if (!version) return undefined;
+    // Don't seed the draft's links with the scratch pseudo-version — the note
+    // links to the playlist, which the backend adds on publish.
+    if (!version || version.id === SCRATCH_VERSION_ID) return undefined;
     return { type: 'Version', id: version.id, name: version.name || `Version ${version.id}` };
   }, [version]);
 
+  const { data: currentUser } = useGetUserByEmail(
+    isScratch ? (userEmail ?? null) : null
+  );
+
   const versionSubmitter = useMemo((): SearchResult | undefined => {
+    // The scratch pad has no submitter; its note defaults "To" the author.
+    if (isScratch) {
+      if (!currentUser) return undefined;
+      return { type: 'User', id: currentUser.id, name: currentUser.name || '' };
+    }
     if (!version?.user) return undefined;
     return { type: 'User', id: version.user.id, name: version.user.name || '' };
-  }, [version?.user]);
+  }, [isScratch, currentUser, version?.user]);
 
   const { draftNote, updateDraftNote, saveAttachmentIds } = useDraftNote({
     playlistId,
@@ -160,7 +184,7 @@ export function ContentArea({
   useHotkeyAction('nextVersion', handleNext);
   useHotkeyAction('previousVersion', handleBack);
   useHotkeyAction('setInReview', handleSetInReview, {
-    enabled: !!version && !!playlistId,
+    enabled: !!version && !!playlistId && !isScratch,
   });
 
   const extensionId =
@@ -260,6 +284,23 @@ export function ContentArea({
             Select a version from the sidebar to view its details
           </EmptyStateText>
         </EmptyState>
+      </ContentWrapper>
+    );
+  }
+
+  if (isScratch) {
+    return (
+      <ContentWrapper>
+        <ScratchTitle>SCRATCH PAD</ScratchTitle>
+        <NoteEditor
+          ref={noteEditorRef}
+          projectId={version.project?.id}
+          currentVersion={null}
+          draftNote={draftNote}
+          updateDraftNote={updateDraftNote}
+          saveAttachmentIds={saveAttachmentIds}
+          defaultHeight={300}
+        />
       </ContentWrapper>
     );
   }

--- a/frontend/packages/app/src/components/PublishNotesDialog.tsx
+++ b/frontend/packages/app/src/components/PublishNotesDialog.tsx
@@ -34,7 +34,13 @@ import {
   type LocalDraftNote,
 } from '../hooks/useDraftNote';
 import { useNoteQCChecks } from '../hooks/useNoteQCChecks';
-import { DraftNote, Version, SearchResult, NoteQCResult } from '@dna/core';
+import {
+  DraftNote,
+  Version,
+  SearchResult,
+  NoteQCResult,
+  SCRATCH_VERSION_ID,
+} from '@dna/core';
 import { NoteEditor, NoteDraftStatusBadges } from './NoteEditor';
 import { UserAvatar } from './UserAvatar';
 import { NoteQCResultPill } from './NoteQCResultPill';
@@ -281,7 +287,10 @@ function fallbackVersion(versionId: number): Version {
   return {
     type: 'Version',
     id: versionId,
-    name: `Version ${versionId}`,
+    name:
+      versionId === SCRATCH_VERSION_ID
+        ? 'SCRATCH PAD'
+        : `Version ${versionId}`,
     notes: [],
   };
 }
@@ -325,13 +334,20 @@ function PublishNoteRow({
   const [fixResult, setFixResult] = useState<NoteQCResult | null>(null);
   const draftKey = draftRowKey(rowDraft);
 
-  const currentVersionAsSearchResult: SearchResult = useMemo(
-    () => ({
-      type: 'Version',
-      id: version.id,
-      name: version.name || `Version ${version.id}`,
-    }),
-    [version.id, version.name]
+  const isScratch = version.id === SCRATCH_VERSION_ID;
+
+  const currentVersionAsSearchResult: SearchResult | undefined = useMemo(
+    () =>
+      // Scratch notes link to the playlist (added on publish), never to the
+      // scratch pseudo-version.
+      isScratch
+        ? undefined
+        : {
+            type: 'Version',
+            id: version.id,
+            name: version.name || `Version ${version.id}`,
+          },
+    [isScratch, version.id, version.name]
   );
 
   const versionSubmitter: SearchResult | undefined = useMemo(() => {
@@ -443,7 +459,7 @@ function PublishNoteRow({
       </Flex>
       <NoteEditor
         projectId={version.project?.id ?? null}
-        currentVersion={version}
+        currentVersion={isScratch ? null : version}
         draftNote={draftNote}
         updateDraftNote={updateDraftNote}
         saveAttachmentIds={saveAttachmentIds}
@@ -690,6 +706,10 @@ function VersionPublishCard({
     [onStatusValueChange, saveVersionStatus]
   );
 
+  // The scratch card publishes a note on the playlist entity: no submitter,
+  // version status, or transcript.
+  const isScratch = version.id === SCRATCH_VERSION_ID;
+
   return (
     <VersionCard>
       <VersionCardHeader>
@@ -704,31 +724,35 @@ function VersionPublishCard({
           >
             {version.name || `Version ${version.id}`}
           </Text>
-          <Flex align="center" gap="2">
-            {version.user ? (
-              <>
-                <UserAvatar name={version.user.name} size="1" />
+          {!isScratch && (
+            <Flex align="center" gap="2">
+              {version.user ? (
+                <>
+                  <UserAvatar name={version.user.name} size="1" />
+                  <Text size="1" color="gray">
+                    {version.user.name}
+                  </Text>
+                </>
+              ) : (
                 <Text size="1" color="gray">
-                  {version.user.name}
+                  Unknown submitter
                 </Text>
-              </>
-            ) : (
-              <Text size="1" color="gray">
-                Unknown submitter
-              </Text>
-            )}
-          </Flex>
+              )}
+            </Flex>
+          )}
         </Flex>
       </VersionCardHeader>
       <Flex direction="column" gap="3" p="3">
-        <VersionStatusRow
-          projectId={version.project?.id}
-          currentStatus={version.status}
-          value={statusValue}
-          checked={statusChecked}
-          onValueChange={handleStatusValueChange}
-          onCheckedChange={onStatusToggle}
-        />
+        {!isScratch && (
+          <VersionStatusRow
+            projectId={version.project?.id}
+            currentStatus={version.status}
+            value={statusValue}
+            checked={statusChecked}
+            onValueChange={handleStatusValueChange}
+            onCheckedChange={onStatusToggle}
+          />
+        )}
         {sortedDrafts.map((d) => (
           <PublishNoteRow
             key={draftRowKey(d)}
@@ -748,12 +772,14 @@ function VersionPublishCard({
             onQcRefreshDraft={() => onQcRefreshDraft(d)}
           />
         ))}
-        <VersionTranscriptRow
-          playlistId={playlistId}
-          versionId={version.id}
-          checked={transcriptChecked}
-          onCheckedChange={onTranscriptToggle}
-        />
+        {!isScratch && (
+          <VersionTranscriptRow
+            playlistId={playlistId}
+            versionId={version.id}
+            checked={transcriptChecked}
+            onCheckedChange={onTranscriptToggle}
+          />
+        )}
       </Flex>
     </VersionCard>
   );
@@ -923,6 +949,14 @@ export const PublishNotesTabContent: React.FC<PublishNotesTabContentProps> = ({
       }
     }
 
+    // The scratch card leads, mirroring its position in the sidebar
+    const scratchIndex = ordered.findIndex(
+      (o) => o.version.id === SCRATCH_VERSION_ID
+    );
+    if (scratchIndex > 0) {
+      ordered.unshift(...ordered.splice(scratchIndex, 1));
+    }
+
     return ordered;
   }, [notes, versions, pendingStatusByVersion]);
 
@@ -1043,7 +1077,11 @@ export const PublishNotesTabContent: React.FC<PublishNotesTabContentProps> = ({
     }));
 
     const selectedTranscriptVersionIds = versionCards
-      .filter(({ version }) => transcriptSelected[version.id] ?? true)
+      .filter(
+        ({ version }) =>
+          version.id !== SCRATCH_VERSION_ID &&
+          (transcriptSelected[version.id] ?? true)
+      )
       .map(({ version }) => version.id);
 
     const [notesResult, transcriptResults, statusResults] = await Promise.all([

--- a/frontend/packages/app/src/components/Sidebar.tsx
+++ b/frontend/packages/app/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 import {
   PanelLeftClose,
@@ -9,6 +10,7 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { Button, Tooltip } from '@radix-ui/themes';
+import { SCRATCH_VERSION_ID } from '@dna/core';
 import type { Version, DraftNote, Playlist } from '@dna/core';
 import { Logo } from './Logo';
 import { UserAvatar } from './UserAvatar';
@@ -21,8 +23,12 @@ import { VersionCard, NoteStatus } from './VersionCard';
 import { TranscriptionMenu } from './TranscriptionMenu';
 import { SettingsModal } from './SettingsModal';
 import { PublishDialog } from './PublishDialog';
-import { useGetVersionsForPlaylist, useGetUserByEmail } from '../api';
-import { usePlaylistMetadata, usePlaylistDraftNotes } from '../hooks';
+import { useGetVersionsForPlaylist, useGetUserByEmail, apiHandler } from '../api';
+import {
+  usePlaylistMetadata,
+  useUpsertPlaylistMetadata,
+  usePlaylistDraftNotes,
+} from '../hooks';
 import { useHotkeyAction, useHotkeyConfig } from '../hotkeys';
 import { useFeatureFlags } from '../contexts';
 
@@ -305,13 +311,77 @@ export function Sidebar({
   const toolbarInputOpen =
     addVersionPlaylistId !== null || changePlaylistProjectId !== null;
 
+  const queryClient = useQueryClient();
+  const upsertPlaylistMetadata = useUpsertPlaylistMetadata(playlistId);
+  const hasScratch = !!playlistMetadata?.has_scratch;
+
+  // Placeholder tile for a note on the playlist entity itself. Not a real
+  // version: excluded from RV sync, in-review, search, and the versions query.
+  const scratchVersion = useMemo<Version>(
+    () => ({
+      type: 'Version',
+      id: SCRATCH_VERSION_ID,
+      name: 'SCRATCH PAD',
+      notes: [],
+      ...(projectId != null
+        ? { project: { type: 'Project', id: projectId } }
+        : {}),
+    }),
+    [projectId]
+  );
+
+  const handleAddScratch = () => {
+    if (!playlistId) return;
+    if (!hasScratch) {
+      void upsertPlaylistMetadata.mutateAsync({ has_scratch: true });
+    }
+    // One scratch per playlist: adding again just selects the existing one.
+    onVersionSelect?.(scratchVersion);
+  };
+
+  const handleRemoveScratch = () => {
+    if (!playlistId) return;
+    void upsertPlaylistMetadata.mutateAsync({ has_scratch: false });
+    void apiHandler
+      .deleteDraftNote({
+        playlistId,
+        versionId: SCRATCH_VERSION_ID,
+        userEmail,
+      })
+      .catch(() => {
+        // No draft to delete is fine.
+      })
+      .finally(() => {
+        queryClient.setQueryData(
+          ['draftNote', playlistId, SCRATCH_VERSION_ID, userEmail],
+          null
+        );
+        void queryClient.invalidateQueries({
+          queryKey: ['draftNotes', playlistId],
+        });
+      });
+    if (selectedVersionId === SCRATCH_VERSION_ID && versions?.length) {
+      onVersionSelect?.(versions[0]);
+    }
+  };
+
   const playlistMenuItems = [
     {
       label: 'Change Playlist',
       onSelect: () => setToolbarInput('change-playlist'),
     },
     { label: 'Add Version', onSelect: () => setToolbarInput('add-version') },
+    { label: 'Add Scratch Pad', onSelect: handleAddScratch },
   ];
+
+  const noteStatusFor = (versionId: number): NoteStatus | null => {
+    const note = draftNotes?.find((n) => n.version_id === versionId);
+    if (!note) return null;
+    if (note.published) return 'published';
+    if (note.published_note_id) return 'edited';
+    if (note.content || note.subject) return 'draft';
+    return null;
+  };
 
   const handleSearchVersionSelect = (version: Version) => {
     onVersionSelect?.(version);
@@ -354,7 +424,7 @@ export function Sidebar({
       );
     }
 
-    if (!versions || versions.length === 0) {
+    if ((!versions || versions.length === 0) && !hasScratch) {
       return (
         <StateContainer>
           <StateText>No versions in this playlist</StateText>
@@ -372,7 +442,26 @@ export function Sidebar({
           </RefetchOverlay>
         )}
         <VersionCardList>
-          {versions.map((version) => (
+          {hasScratch && (
+            <div
+              ref={(el) => {
+                if (el) {
+                  versionRefs.current.set(SCRATCH_VERSION_ID, el);
+                } else {
+                  versionRefs.current.delete(SCRATCH_VERSION_ID);
+                }
+              }}
+            >
+              <VersionCard
+                version={scratchVersion}
+                selected={selectedVersionId === SCRATCH_VERSION_ID}
+                noteStatus={noteStatusFor(SCRATCH_VERSION_ID)}
+                onClick={() => onVersionSelect?.(scratchVersion)}
+                onRemove={handleRemoveScratch}
+              />
+            </div>
+          )}
+          {(versions ?? []).map((version) => (
             <div
               key={version.id}
               ref={(el) => {
@@ -390,16 +479,7 @@ export function Sidebar({
                 thumbnailUrl={version.thumbnail}
                 selected={version.id === selectedVersionId}
                 inReview={inReviewEnabled && inReviewVersionId === version.id}
-                noteStatus={((): NoteStatus | null => {
-                  const note = draftNotes?.find(
-                    (n) => n.version_id === version.id
-                  );
-                  if (!note) return null;
-                  if (note.published) return 'published';
-                  if (note.published_note_id) return 'edited';
-                  if (note.content || note.subject) return 'draft';
-                  return null;
-                })()}
+                noteStatus={noteStatusFor(version.id)}
                 onClick={() => onVersionSelect?.(version)}
               />
             </div>

--- a/frontend/packages/app/src/components/VersionCard.test.tsx
+++ b/frontend/packages/app/src/components/VersionCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { Theme } from '@radix-ui/themes';
+import type { Version } from '@dna/core';
+import { darkTheme } from '../styles/theme';
+import { VersionCard } from './VersionCard';
+
+const version = { id: 7190, name: 'TST_010_0010_comp_v001' } as Version;
+
+function renderCard(props: Partial<Parameters<typeof VersionCard>[0]> = {}) {
+  return render(
+    <ThemeProvider theme={darkTheme}>
+      <Theme>
+        <VersionCard version={version} {...props} />
+      </Theme>
+    </ThemeProvider>
+  );
+}
+
+describe('VersionCard scratch removal', () => {
+  it('renders the remove X in place of the in-review eye', () => {
+    renderCard({ onRemove: vi.fn(), inReview: true });
+
+    expect(
+      screen.getByRole('button', { name: 'Remove scratch pad' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('removes without selecting the tile', () => {
+    const onClick = vi.fn();
+    const onRemove = vi.fn();
+    renderCard({ onClick, onRemove });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove scratch pad' }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/app/src/components/VersionCard.tsx
+++ b/frontend/packages/app/src/components/VersionCard.tsx
@@ -1,7 +1,8 @@
 import { useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styled, { type DefaultTheme } from 'styled-components';
-import { Eye } from 'lucide-react';
+import { Eye, NotebookPen, X } from 'lucide-react';
+import { Tooltip } from '@radix-ui/themes';
 import type { Version } from '@dna/core';
 import { UserAvatar } from './UserAvatar';
 
@@ -16,6 +17,12 @@ interface VersionCardProps {
   inReview?: boolean;
   noteStatus?: NoteStatus | null;
   onClick?: () => void;
+  /**
+   * Renders an X where the in-review eye would sit, for tiles that can be
+   * removed instead of reviewed (scratch tiles). Mutually exclusive with the
+   * eye: when set, inReview is ignored.
+   */
+  onRemove?: () => void;
 }
 
 const Card = styled.div<{ $selected?: boolean }>`
@@ -51,6 +58,20 @@ const Thumbnail = styled.div`
   }
 `;
 
+const ScratchThumb = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.text.muted};
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
 const Content = styled.div`
   display: flex;
   flex-direction: column;
@@ -83,6 +104,53 @@ const InReviewIcon = styled.span`
   align-items: center;
   justify-content: center;
   color: ${({ theme }) => theme.colors.accent.main};
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+/**
+ * Hidden until the card is hovered, then a muted gray; glows red while the
+ * button itself is hovered or focused.
+ */
+const RemoveToggle = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.text.muted};
+  opacity: 0;
+  transition: opacity ${({ theme }) => theme.transitions.fast},
+    color ${({ theme }) => theme.transitions.fast},
+    filter ${({ theme }) => theme.transitions.fast};
+
+  /* Nested so these keep winning over the card-hover reveal above. */
+  ${Card}:hover & {
+    opacity: 0.5;
+
+    &:hover,
+    &:focus-visible {
+      opacity: 1;
+    }
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: ${({ theme }) => theme.colors.status.error};
+    filter: drop-shadow(0 0 4px ${({ theme }) => theme.colors.status.error});
+  }
+
+  &:focus-visible {
+    opacity: 1;
+    outline: 2px solid ${({ theme }) => theme.colors.status.error};
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
 
   svg {
     width: 16px;
@@ -200,6 +268,7 @@ export function VersionCard({
   inReview = false,
   noteStatus = null,
   onClick,
+  onRemove,
 }: VersionCardProps) {
   const displayName = version.name || `Version ${version.id}`;
 
@@ -219,10 +288,39 @@ export function VersionCard({
     }
   };
 
+  const renderRemove = () => (
+    <Tooltip content="Remove scratch pad">
+      <RemoveToggle
+        type="button"
+        aria-label="Remove scratch pad"
+        onClick={(e) => {
+          // Removing shouldn't drag the selection along with it.
+          e.stopPropagation();
+          onRemove?.();
+        }}
+      >
+        <X />
+      </RemoveToggle>
+    </Tooltip>
+  );
+
+  const renderEye = () =>
+    inReview ? (
+      <InReviewIcon>
+        <Eye />
+      </InReviewIcon>
+    ) : null;
+
   return (
     <Card $selected={selected} onClick={onClick}>
       <Thumbnail>
-        {thumbnailUrl && <img src={thumbnailUrl} alt={displayName} />}
+        {thumbnailUrl ? (
+          <img src={thumbnailUrl} alt={displayName} />
+        ) : onRemove ? (
+          <ScratchThumb>
+            <NotebookPen aria-label="Scratch pad" />
+          </ScratchThumb>
+        ) : null}
       </Thumbnail>
       <Content>
         <Title>{displayName}</Title>
@@ -242,11 +340,7 @@ export function VersionCard({
             letter={getStatusLetter(noteStatus)}
           />
         )}
-        {inReview && (
-          <InReviewIcon>
-            <Eye />
-          </InReviewIcon>
-        )}
+        {onRemove ? renderRemove() : renderEye()}
       </IconsContainer>
     </Card>
   );

--- a/frontend/packages/core/src/interfaces.ts
+++ b/frontend/packages/core/src/interfaces.ts
@@ -143,6 +143,13 @@ export interface GetUserByEmailParams {
   userEmail: string;
 }
 
+/**
+ * Sentinel version_id for a playlist-level "scratch" note: the draft belongs
+ * to the playlist itself rather than any version, and publishes as a note
+ * linked only to the Playlist entity.
+ */
+export const SCRATCH_VERSION_ID = -1;
+
 export interface DraftNoteLink {
   entity_type: string;
   entity_id: number;
@@ -210,6 +217,7 @@ export interface PlaylistMetadata {
   meeting_id: string | null;
   platform: Platform | null;
   transcription_paused: boolean;
+  has_scratch: boolean;
 }
 
 export interface PlaylistMetadataUpdate {
@@ -217,6 +225,7 @@ export interface PlaylistMetadataUpdate {
   meeting_id?: string | null;
   platform?: Platform | null;
   transcription_paused?: boolean;
+  has_scratch?: boolean;
 }
 
 export interface GetPlaylistMetadataParams {


### PR DESCRIPTION
Add Scratch Pad: playlist-level notes as a sidebar tile - based on request from SPI. 

### Summary

Adds an **Add Scratch Pad** option to the sidebar's playlist menu (under Add Version). It creates a placeholder tile that represents a note on the **playlist entity** in ShotGrid rather than on any version — for review-wide observations that don't belong to a single shot.

- One scratch pad per playlist, shared across users (persisted in `playlist_metadata`)
- Publishes through the existing Publish Notes dialog as a note linked **only to the Playlist entity**, with the project derived from the playlist
- Completely excluded from RV sync, in-review, version search, transcripts, and version-status updates
- Removed via an X control on the tile (replacing where the in-review eye will normally sit once introduced in a future PR)

### How it works

The scratch note rides the existing draft-note pipeline under a sentinel version id (`SCRATCH_VERSION_ID = -1`), shared between `@dna/core` and `dna.models`. The tile's existence is a `has_scratch` flag on the playlist metadata doc.

**Backend**
- `playlist_metadata.py`: new `has_scratch` field on `PlaylistMetadata` / `PlaylistMetadataUpdate`
- `shotgrid.py` + provider base: new `publish_playlist_note()` — playlist-only note link, project from playlist, same duplicate-check and author-sudo behavior as version notes
- `main.py`: `publish_notes` branches on the sentinel — scratch drafts route to `publish_playlist_note`, never touch version status, and pseudo-version links are stripped; republishing edits reuses `update_note` unchanged

**Frontend**
- `Sidebar.tsx`: menu item (re-selects the existing pad if one exists), tile rendered at the top of the version list, removal clears the flag and deletes the user's scratch draft
- `VersionCard.tsx`: scratch tiles show a NotebookPen icon in the thumbnail slot and an X replacing the (to be added) in-review eye — hidden until card hover, muted gray, glows red on button hover
- `ContentArea.tsx`: SCRATCH PAD title + note editor only (no version header, AI Assistant, or Transcript; in-review hotkey disabled); the To field defaults to the note's author
- `PublishNotesDialog.tsx`: scratch draft renders as a leading SCRATCH PAD card with just the note row; excluded from transcript publishing

## Testing
- [x] I have tested these changes locally
- [x] I have run all relevant automated tests
- [x] I have verified this does not break existing workflows
- [x] For changes that can be tested in UI, I have included screenshots or gif animations of the changes.

## How I Tested
Stood up application and tested feature.

<img width="640" height="465" alt="scratch" src="https://github.com/user-attachments/assets/296ede6e-453f-4769-9cfd-327fc85638b9" />
